### PR TITLE
Fix admin login by sending basic auth header

### DIFF
--- a/src/shared/model/auth.tsx
+++ b/src/shared/model/auth.tsx
@@ -53,9 +53,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   async function login(username: string, password: string): Promise<boolean> {
     try {
+      const tokenPayload = `${username}:${password}`;
+      const encodedToken = window.btoa(
+        String.fromCharCode(...new TextEncoder().encode(tokenPayload)),
+      );
+
       const data = await apiClient<AuthLoginResponse>('/auth/login', {
         method: 'POST',
-        body: JSON.stringify({ username, password }),
+        headers: {
+          Authorization: `Basic ${encodedToken}`,
+        },
+        body: JSON.stringify({ username, login: username, password }),
       });
 
       if (!data?.token) {


### PR DESCRIPTION
## Summary
- send the Basic Authorization header when performing the admin login request
- duplicate the username into the `login` field to match the backend contract

## Testing
- npm test *(fails: existing SearchPage tests require a QueryClient provider and fail with "No QueryClient set" error)*

------
https://chatgpt.com/codex/tasks/task_e_68e2db5d862c832aa94d79d1550f1d24