### PR TITLE
feat: support basic auth login

### DIFF
--- a/src/pages/ArticleForm/ArticleForm.tsx
+++ b/src/pages/ArticleForm/ArticleForm.tsx
@@ -1,4 +1,5 @@
 import { useState, type FormEvent } from 'react';
+import { useAuth } from '../../shared/model/auth';
 
 export type ArticleFormMode = 'create' | 'edit';
 
@@ -10,6 +11,7 @@ export function ArticleForm({ mode }: ArticleFormProps) {
   const [title, setTitle] = useState('');
   const [slug, setSlug] = useState('');
   const [body, setBody] = useState('');
+  const { authHeader } = useAuth();
 
   const baseUrl = import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, '') || '';
 
@@ -19,7 +21,10 @@ export function ArticleForm({ mode }: ArticleFormProps) {
 
     const res = await fetch(`${baseUrl}/articles`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authHeader ? { Authorization: authHeader } : {}),
+      },
       body: JSON.stringify(payload),
     });
 


### PR DESCRIPTION
## Summary
- persist the authenticated state as either bearer tokens or basic credentials so `/auth/me` can be called with the correct scheme
- update the login flow to authenticate against basic-auth backends and expose the computed Authorization header through context
- attach the active Authorization header when creating articles from the admin form

## Testing
- npm run test *(fails: vitest requires a QueryClient provider in watch mode in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ee9c6220832a8dbe60a4c5edcecd