### PR TITLE
Wrap app with shared providers

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,24 +1,10 @@
-import { Routes, Route } from 'react-router-dom';
-import { LoginPage } from '../pages/LoginPage/LoginPage';
-import { SearchPage } from '../pages/SearchPage/SearchPage';
-import { RequireAuth } from '../shared/ui/RequireAuth';
-import { Layout } from '../shared/ui/Layout/Layout';
+import { AppProviders } from './providers/AppProviders';
+import { AppRouter } from './providers/AppRouter';
 
 export default function App() {
   return (
-    <Layout>
-      <Routes>
-        <Route path="/" element={<SearchPage />} />
-        <Route path="/admin/login" element={<LoginPage />} />
-        <Route
-          path="/admin/*"
-          element={
-            <RequireAuth>
-              <div>Админка</div>
-            </RequireAuth>
-          }
-        />
-      </Routes>
-    </Layout>
+    <AppProviders>
+      <AppRouter />
+    </AppProviders>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
 import App from './app/App';
-import { AuthProvider } from './shared/model/auth';
 
 const container = document.getElementById('root')!;
 const root = createRoot(container);
 
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    </BrowserRouter>
+    <App />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- wrap the application with the shared AppProviders wrapper so the QueryClient and theme are available
- switch to the shared AppRouter to host BrowserRouter and authentication context logic in one place

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e2f317a914832a87ccadda85ce2ae8