### PR TITLE
Revamp UI with gradient glassmorphism styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Инструкции — база знаний</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './app/App';
+import './shared/styles/globals.css';
 
 const container = document.getElementById('root')!;
 const root = createRoot(container);

--- a/src/pages/ArticlePage/ArticlePage.module.css
+++ b/src/pages/ArticlePage/ArticlePage.module.css
@@ -1,48 +1,103 @@
 .layout {
   display: flex;
-  gap: 2rem;
+  gap: clamp(2.25rem, 4vw, 3rem);
+  align-items: flex-start;
 }
 
 .content {
   flex: 1;
   display: grid;
-  gap: 2rem;
+  gap: clamp(2rem, 4vw, 2.75rem);
 }
 
 .header {
+  position: relative;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
   display: grid;
-  gap: 0.75rem;
+  gap: 0.85rem;
+  border-radius: 1.75rem;
+  background: var(--gradient-hero);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+  isolation: isolate;
+  backdrop-filter: var(--glass-blur);
+}
+
+.header::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(80% 100% at 90% 0%, rgba(47, 92, 255, 0.22), rgba(47, 92, 255, 0));
+  opacity: 0.9;
+  z-index: -1;
 }
 
 .title {
   margin: 0;
-  font-size: clamp(2.25rem, 3vw, 3rem);
+  font-size: clamp(2.35rem, 4vw, 3.25rem);
+  letter-spacing: -0.015em;
 }
 
 .description {
   margin: 0;
   color: var(--muted);
-  font-size: 1.125rem;
+  font-size: clamp(1.1rem, 2vw, 1.25rem);
+  max-width: 70ch;
 }
 
 .meta {
-  color: var(--muted);
-  font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--primary-strong);
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(47, 92, 255, 0.18);
+}
+
+[data-theme='dark'] .meta {
+  background: rgba(13, 25, 52, 0.75);
+  border-color: rgba(107, 139, 255, 0.3);
+  color: #a8c4ff;
 }
 
 .markdown {
-  background: var(--bg-elev);
-  border-radius: 1.25rem;
-  border: 1px solid var(--border);
-  padding: 2.5rem;
+  position: relative;
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 1.75rem;
+  border: 1px solid transparent;
+  padding: clamp(2.2rem, 4vw, 2.8rem);
   box-shadow: var(--shadow);
+  backdrop-filter: var(--glass-blur);
+  overflow: hidden;
+}
+
+[data-theme='dark'] .markdown {
+  background: rgba(13, 25, 52, 0.9);
+}
+
+.markdown::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background: var(--gradient-card);
+  opacity: 0.9;
+  z-index: -1;
 }
 
 .error {
-  padding: 2rem;
-  border-radius: 1rem;
-  background: rgba(220, 38, 38, 0.12);
-  color: #7f1d1d;
+  padding: 2.2rem;
+  border-radius: 1.25rem;
+  background: rgba(255, 87, 87, 0.12);
+  color: #9f2b2b;
+  border: 1px solid rgba(255, 87, 87, 0.25);
+  box-shadow: 0 18px 30px -25px rgba(159, 43, 43, 0.6);
 }
 
 .tocToggle {
@@ -51,7 +106,7 @@
 
 @media (max-width: 1280px) {
   .markdown {
-    padding: 2rem;
+    padding: 2.1rem;
   }
 }
 
@@ -65,16 +120,30 @@
     align-self: flex-start;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    border-radius: 9999px;
-    border: 1px solid var(--border);
-    background: var(--bg-elev);
+    padding: 0.65rem 1.25rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-strong);
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.75));
     cursor: pointer;
+    font-weight: 600;
+    color: var(--primary-strong);
+    box-shadow: var(--shadow);
+  }
+
+  [data-theme='dark'] .tocToggle {
+    background: linear-gradient(135deg, rgba(13, 25, 52, 0.9), rgba(13, 25, 52, 0.75));
+    color: var(--text);
   }
 }
 
 @media (max-width: 640px) {
   .markdown {
-    padding: 1.5rem;
+    padding: 1.7rem;
+    border-radius: 1.4rem;
+  }
+
+  .header {
+    border-radius: 1.4rem;
+    padding: 1.8rem;
   }
 }

--- a/src/pages/HomePage/HomePage.module.css
+++ b/src/pages/HomePage/HomePage.module.css
@@ -1,68 +1,151 @@
 .root {
   display: grid;
-  gap: 2rem;
+  gap: clamp(2.5rem, 3vw, 3rem);
 }
 
 .hero {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
   display: grid;
-  gap: 0.75rem;
+  gap: 1rem;
+  padding: clamp(2.25rem, 4vw, 3.25rem);
+  border-radius: 2rem;
+  background: var(--gradient-hero);
+  box-shadow: var(--shadow-card);
+}
+
+.hero::before,
+.hero::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(0);
+  opacity: 0.7;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.hero::before {
+  width: clamp(260px, 40vw, 420px);
+  height: clamp(260px, 40vw, 420px);
+  background: radial-gradient(circle, rgba(47, 92, 255, 0.28) 0%, rgba(47, 92, 255, 0) 70%);
+  top: -40%;
+  right: -20%;
+}
+
+.hero::after {
+  width: clamp(200px, 30vw, 320px);
+  height: clamp(200px, 30vw, 320px);
+  background: radial-gradient(circle, rgba(68, 199, 244, 0.32) 0%, rgba(68, 199, 244, 0) 70%);
+  bottom: -35%;
+  left: -10%;
 }
 
 .title {
-  font-size: clamp(2rem, 3vw, 2.75rem);
+  font-size: clamp(2.25rem, 5vw, 3.4rem);
   margin: 0;
+  letter-spacing: -0.01em;
 }
 
 .subtitle {
   margin: 0;
   color: var(--muted);
   max-width: 640px;
+  font-size: clamp(1.05rem, 2vw, 1.2rem);
 }
 
 .state {
   color: var(--muted);
+  font-size: 1.05rem;
 }
 
 .list {
   display: grid;
-  gap: 1.5rem;
+  gap: clamp(1.5rem, 3vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   padding: 0;
   margin: 0;
   list-style: none;
 }
 
 .card {
-  background: var(--bg-elev);
-  border-radius: 1rem;
-  border: 1px solid var(--border);
+  position: relative;
+  border-radius: 1.4rem;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid transparent;
   box-shadow: var(--shadow);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  backdrop-filter: var(--glass-blur);
+  overflow: hidden;
+}
+
+[data-theme='dark'] .card {
+  background: rgba(13, 25, 52, 0.8);
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background: var(--gradient-card);
+  opacity: 0.85;
+  z-index: -1;
 }
 
 .link {
-  display: block;
-  padding: 1.5rem;
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.75rem;
   color: inherit;
   text-decoration: none;
 }
 
 .card:hover,
 .card:focus-within {
-  transform: translateY(-4px);
-  box-shadow: 0 16px 40px rgba(99, 91, 255, 0.2);
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-card);
 }
 
 .cardTitle {
-  margin: 0 0 0.5rem;
-  font-size: 1.5rem;
+  margin: 0;
+  font-size: 1.45rem;
+  letter-spacing: -0.01em;
 }
 
 .cardDescription {
-  margin: 0 0 1rem;
+  margin: 0;
   color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
 }
 
 .meta {
-  font-size: 0.875rem;
-  color: var(--muted);
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--primary-strong);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(68, 199, 244, 0.14);
+}
+
+[data-theme='dark'] .meta {
+  background: rgba(68, 199, 244, 0.22);
+  color: #7ed3ff;
+}
+
+@media (max-width: 640px) {
+  .hero {
+    border-radius: 1.5rem;
+    padding: 2rem;
+  }
+
+  .link {
+    padding: 1.5rem;
+  }
 }

--- a/src/pages/LoginPage/LoginPage.module.css
+++ b/src/pages/LoginPage/LoginPage.module.css
@@ -1,21 +1,28 @@
+
 .root {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 4rem 1.5rem;
-  min-height: min(80vh, 680px);
+  padding: clamp(4rem, 5vw, 5.5rem) 1.5rem;
+  min-height: min(80vh, 720px);
 }
 
 .card {
   width: min(420px, 100%);
-  background: var(--bg-elev);
-  border-radius: 1rem;
-  padding: 2.5rem 2.25rem;
-  box-shadow: 0 30px 60px -40px rgba(99, 91, 255, 0.45);
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 1.35rem;
+  padding: clamp(2.25rem, 4vw, 2.8rem) clamp(2rem, 4vw, 2.4rem);
+  box-shadow: 0 35px 70px -45px rgba(31, 73, 182, 0.55);
   border: 1px solid rgba(255, 255, 255, 0.6);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  backdrop-filter: var(--glass-blur);
+}
+
+[data-theme='dark'] .card {
+  background: rgba(13, 25, 52, 0.9);
+  border-color: rgba(107, 139, 255, 0.35);
 }
 
 .title {

--- a/src/pages/NotFoundPage/NotFoundPage.module.css
+++ b/src/pages/NotFoundPage/NotFoundPage.module.css
@@ -1,33 +1,39 @@
 .root {
-  padding: 4rem 0;
+  padding: 5rem 0;
   display: grid;
-  gap: 1.5rem;
+  gap: 1.75rem;
   text-align: center;
 }
 
 .title {
-  font-size: 2rem;
+  font-size: clamp(2rem, 4vw, 2.6rem);
   font-weight: 700;
+  letter-spacing: -0.01em;
 }
 
 .text {
-  max-width: 540px;
+  max-width: 560px;
   margin: 0 auto;
   color: var(--muted);
+  font-size: 1.05rem;
 }
 
 .link {
   justify-self: center;
-  padding: 0.75rem 1.5rem;
+  padding: 0.85rem 1.85rem;
   border-radius: 9999px;
   border: none;
-  background: var(--primary);
+  background: linear-gradient(135deg, var(--primary), var(--primary-strong));
   color: #fff;
   text-decoration: none;
   font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow: 0 22px 38px -26px rgba(47, 92, 255, 0.85);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .link:hover,
 .link:focus-visible {
-  opacity: 0.9;
+  transform: translateY(-1px);
+  box-shadow: 0 30px 48px -28px rgba(47, 92, 255, 0.9);
 }

--- a/src/pages/SearchPage/SearchPage.module.css
+++ b/src/pages/SearchPage/SearchPage.module.css
@@ -1,15 +1,27 @@
 .root {
   display: grid;
-  gap: 2rem;
+  gap: clamp(2rem, 3vw, 2.75rem);
 }
 
 .title {
   margin: 0;
-  font-size: clamp(2rem, 3vw, 2.5rem);
+  font-size: clamp(2.1rem, 4vw, 2.8rem);
+  letter-spacing: -0.01em;
 }
 
 .form {
-  max-width: 640px;
+  max-width: 680px;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 1.5rem;
+  padding: 1rem 1.25rem;
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  backdrop-filter: var(--glass-blur);
+}
+
+[data-theme='dark'] .form {
+  background: rgba(13, 25, 52, 0.85);
+  border-color: rgba(107, 139, 255, 0.25);
 }
 
 .label {
@@ -18,25 +30,36 @@
 
 .input {
   width: 100%;
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
-  border: 1px solid var(--border);
+  padding: 0.9rem 1.1rem;
+  border-radius: 1rem;
+  border: 1px solid transparent;
   font-size: 1rem;
   font-family: var(--font-sans);
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: inset 0 0 0 1px rgba(47, 92, 255, 0.12);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+[data-theme='dark'] .input {
+  background: rgba(13, 25, 52, 0.95);
+  box-shadow: inset 0 0 0 1px rgba(107, 139, 255, 0.3);
+  color: var(--text);
 }
 
 .input:focus-visible {
-  outline: 2px solid var(--primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--primary), 0 12px 28px -20px rgba(47, 92, 255, 0.8);
+  transform: translateY(-1px);
 }
 
 .state {
   color: var(--muted);
+  font-size: 1rem;
 }
 
 .results {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .list {
@@ -44,71 +67,133 @@
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 1rem;
+  gap: clamp(1.1rem, 2.5vw, 1.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
 .card {
-  border: 1px solid var(--border);
-  border-radius: 1rem;
-  background: var(--bg-elev);
+  position: relative;
+  border-radius: 1.35rem;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid transparent;
   box-shadow: var(--shadow);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  overflow: hidden;
+  backdrop-filter: var(--glass-blur);
+}
+
+[data-theme='dark'] .card {
+  background: rgba(13, 25, 52, 0.82);
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background: var(--gradient-card);
+  opacity: 0.85;
+  z-index: -1;
 }
 
 .link {
   display: grid;
-  gap: 0.75rem;
-  padding: 1.5rem;
+  gap: 0.9rem;
+  padding: 1.75rem 1.6rem;
   color: inherit;
   text-decoration: none;
 }
 
+.card:hover,
+.card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-card);
+}
+
 .badge {
   align-self: flex-start;
-  padding: 0.25rem 0.75rem;
+  padding: 0.35rem 0.95rem;
   border-radius: 9999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  background: rgba(99, 91, 255, 0.1);
-  color: var(--primary);
+  font-size: 0.72rem;
+  font-weight: 700;
+  background: rgba(47, 92, 255, 0.14);
+  color: var(--primary-strong);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
 }
 
 .badge[data-type='article'] {
-  background: rgba(37, 99, 235, 0.12);
-  color: #1d4ed8;
+  background: rgba(68, 199, 244, 0.14);
+  color: #0e6bc0;
+}
+
+[data-theme='dark'] .badge[data-type='article'] {
+  color: #7ed3ff;
 }
 
 .cardTitle {
   margin: 0;
-  font-size: 1.25rem;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
 }
 
 .snippet {
   margin: 0;
   color: var(--muted);
+  line-height: 1.6;
 }
 
 .pagination {
   display: flex;
+  justify-content: center;
   align-items: center;
-  gap: 1rem;
+  gap: 1.25rem;
+  flex-wrap: wrap;
 }
 
 .pageButton {
-  padding: 0.5rem 1rem;
+  padding: 0.55rem 1.4rem;
   border-radius: 9999px;
-  border: 1px solid var(--border);
-  background: var(--bg-elev);
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.75));
   cursor: pointer;
+  font-weight: 600;
+  color: var(--primary-strong);
+  box-shadow: var(--shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+[data-theme='dark'] .pageButton {
+  background: linear-gradient(135deg, rgba(13, 25, 52, 0.9), rgba(13, 25, 52, 0.8));
+  color: var(--text);
+  box-shadow: 0 15px 30px -25px rgba(0, 0, 0, 0.8);
+}
+
+.pageButton:hover:not(:disabled),
+.pageButton:focus-visible:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-card);
 }
 
 .pageButton:disabled {
-  opacity: 0.4;
+  opacity: 0.45;
   cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 .pageInfo {
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .form {
+    border-radius: 1.25rem;
+    padding: 0.85rem 1rem;
+  }
+
+  .link {
+    padding: 1.5rem;
+  }
 }

--- a/src/shared/styles/globals.css
+++ b/src/shared/styles/globals.css
@@ -12,10 +12,25 @@ html {
 body {
   margin: 0;
   font-family: var(--font-sans);
-  background: var(--bg);
+  background-color: var(--bg);
+  background-image: var(--gradient-hero);
+  background-attachment: fixed;
   color: var(--text);
   min-height: 100vh;
   line-height: 1.6;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: -40vh -20vw 40vh;
+  background: radial-gradient(80% 80% at 30% 20%, rgba(68, 199, 244, 0.18), rgba(68, 199, 244, 0)),
+    radial-gradient(90% 90% at 80% 10%, rgba(47, 92, 255, 0.15), rgba(47, 92, 255, 0));
+  z-index: -2;
+  opacity: 0.8;
+  pointer-events: none;
 }
 
 a {
@@ -64,4 +79,6 @@ code {
 
 main {
   display: block;
+  position: relative;
+  z-index: 1;
 }

--- a/src/shared/styles/tokens.css
+++ b/src/shared/styles/tokens.css
@@ -1,23 +1,39 @@
 :root {
-  --bg: #f7f8fa;
-  --bg-elev: #ffffff;
-  --text: #1f2a37;
-  --muted: #5f6b7a;
-  --primary: #635bff;
-  --link: #2563eb;
-  --border: #d0d7e2;
+  --bg: #f1f5ff;
+  --bg-elev: rgba(255, 255, 255, 0.88);
+  --text: #10243b;
+  --muted: #5c6c86;
+  --primary: #2f5cff;
+  --primary-strong: #2446d8;
+  --link: #1578ff;
+  --border: rgba(47, 92, 255, 0.18);
+  --border-strong: rgba(47, 92, 255, 0.35);
+  --gradient-hero: radial-gradient(120% 140% at 12% 12%, rgba(68, 199, 244, 0.45) 0%, rgba(68, 199, 244, 0) 58%),
+    radial-gradient(120% 120% at 85% 0%, rgba(47, 92, 255, 0.4) 0%, rgba(47, 92, 255, 0) 55%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.72) 0%, rgba(255, 255, 255, 0.45) 100%);
+  --gradient-card: linear-gradient(135deg, rgba(47, 92, 255, 0.18) 0%, rgba(68, 199, 244, 0.16) 100%);
+  --shadow: 0 26px 60px -42px rgba(16, 54, 126, 0.65);
+  --shadow-card: 0 30px 70px -45px rgba(31, 73, 182, 0.55);
+  --glass-blur: saturate(180%) blur(24px);
   --font-sans: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
   --font-mono: 'Fira Code', 'SFMono-Regular', ui-monospace, monospace;
-  --shadow: 0 12px 30px rgba(99, 91, 255, 0.15);
 }
 
 [data-theme='dark'] {
-  --bg: #0f172a;
-  --bg-elev: #1e293b;
-  --text: #f8fafc;
-  --muted: #94a3b8;
-  --primary: #818cf8;
-  --link: #60a5fa;
-  --border: #334155;
-  --shadow: 0 12px 30px rgba(129, 140, 248, 0.25);
+  --bg: #0a1327;
+  --bg-elev: rgba(13, 25, 52, 0.92);
+  --text: #f0f6ff;
+  --muted: #9bb3df;
+  --primary: #6b8bff;
+  --primary-strong: #5670e6;
+  --link: #7ec8ff;
+  --border: rgba(107, 139, 255, 0.35);
+  --border-strong: rgba(126, 200, 255, 0.35);
+  --gradient-hero: radial-gradient(120% 140% at 8% 10%, rgba(78, 199, 244, 0.25) 0%, rgba(78, 199, 244, 0) 60%),
+    radial-gradient(120% 140% at 90% 0%, rgba(107, 139, 255, 0.4) 0%, rgba(107, 139, 255, 0) 58%),
+    linear-gradient(150deg, rgba(17, 35, 69, 0.85) 0%, rgba(10, 19, 39, 0.95) 100%);
+  --gradient-card: linear-gradient(135deg, rgba(107, 139, 255, 0.24) 0%, rgba(126, 200, 255, 0.22) 100%);
+  --shadow: 0 26px 60px -40px rgba(4, 12, 30, 0.85);
+  --shadow-card: 0 40px 80px -45px rgba(8, 19, 44, 0.9);
+  --glass-blur: saturate(180%) blur(26px);
 }

--- a/src/shared/ui/Layout/Layout.module.css
+++ b/src/shared/ui/Layout/Layout.module.css
@@ -1,21 +1,38 @@
 .root {
   min-height: 100vh;
-  background: var(--bg);
   color: var(--text);
   display: flex;
   flex-direction: column;
+  position: relative;
+  isolation: isolate;
+}
+
+.root::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(60% 90% at 12% -10%, rgba(47, 92, 255, 0.12), transparent 55%),
+    radial-gradient(45% 60% at 90% 0%, rgba(68, 199, 244, 0.16), transparent 60%);
+  z-index: -1;
+  pointer-events: none;
 }
 
 .header {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 20;
   display: flex;
   align-items: center;
-  padding: 0.75rem 1.5rem;
-  background: var(--bg-elev);
-  box-shadow: var(--shadow);
+  justify-content: center;
+  padding: 1rem 1.75rem;
+  backdrop-filter: var(--glass-blur);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.65));
   border-bottom: 1px solid var(--border);
+  box-shadow: 0 20px 40px -32px rgba(16, 33, 71, 0.35);
+}
+
+[data-theme='dark'] .header {
+  background: linear-gradient(180deg, rgba(13, 24, 52, 0.95), rgba(13, 24, 52, 0.75));
 }
 
 .nav {
@@ -25,6 +42,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
+  max-width: 1100px;
 }
 
 .actions {
@@ -35,46 +53,57 @@
 }
 
 .link {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.5rem 0.9rem;
-  border-radius: 0.75rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
   text-decoration: none;
   font-weight: 500;
   color: var(--muted);
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  letter-spacing: 0.01em;
+  transition: color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  background: rgba(255, 255, 255, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+  backdrop-filter: var(--glass-blur);
+}
+
+[data-theme='dark'] .link {
+  background: rgba(13, 25, 52, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(107, 139, 255, 0.2);
 }
 
 .link:hover,
 .link:focus-visible {
-  color: var(--text);
-  background: rgba(0, 0, 0, 0.04);
-  box-shadow: inset 0 0 0 1px var(--border);
+  color: var(--primary-strong);
+  box-shadow: inset 0 0 0 1px var(--border-strong), 0 12px 24px -18px rgba(47, 92, 255, 0.6);
+  transform: translateY(-1px);
 }
 
 .linkActive {
   color: var(--primary);
-  box-shadow: inset 0 0 0 1px var(--primary);
-  background: rgba(0, 123, 255, 0.08);
+  box-shadow: inset 0 0 0 1px var(--primary), 0 16px 28px -20px rgba(47, 92, 255, 0.7);
+  background: linear-gradient(135deg, rgba(47, 92, 255, 0.18), rgba(68, 199, 244, 0.12));
 }
 
 .button {
-  padding: 0.5rem 1rem;
-  border-radius: 0.75rem;
+  padding: 0.55rem 1.2rem;
+  border-radius: 999px;
   border: none;
-  background: var(--primary);
+  background: linear-gradient(135deg, var(--primary), var(--primary-strong));
   color: white;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 16px 30px -20px rgba(47, 92, 255, 0.75);
 }
 
 .button:hover,
 .button:focus-visible {
-  background: #4f46e5;
   transform: translateY(-1px);
-  box-shadow: 0 10px 18px -12px rgba(15, 98, 254, 0.6);
+  box-shadow: 0 25px 35px -20px rgba(47, 92, 255, 0.85);
 }
 
 .button:active {
@@ -83,28 +112,29 @@
 
 .main {
   flex: 1;
-  padding: 2rem;
+  padding: clamp(2rem, 4vw, 3rem);
   margin: 0 auto;
-  width: min(1200px, 100%);
+  width: min(1240px, 100%);
 }
 
 @media (max-width: 768px) {
   .header {
-    justify-content: center;
+    padding: 0.85rem 1.25rem;
   }
 
   .main {
-    padding: 1.5rem 1rem 3rem;
+    padding: 1.75rem 1.1rem 3.5rem;
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 520px) {
   .nav {
-    gap: 0.5rem;
+    gap: 0.6rem;
   }
 
   .link,
   .button {
     width: 100%;
+    justify-content: center;
   }
 }

--- a/src/shared/ui/PageSpinner/PageSpinner.module.css
+++ b/src/shared/ui/PageSpinner/PageSpinner.module.css
@@ -1,23 +1,27 @@
 .container {
   display: grid;
   place-items: center;
-  gap: 0.75rem;
-  padding: 4rem 0;
+  gap: 1rem;
+  padding: 4.5rem 0;
   color: var(--muted);
 }
 
 .spinner {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 3rem;
+  height: 3rem;
   border-radius: 50%;
-  border: 4px solid var(--border);
-  border-top-color: var(--primary);
-  animation: spin 0.8s linear infinite;
+  border: 3px solid rgba(47, 92, 255, 0.2);
+  border-top: 3px solid var(--primary);
+  border-right: 3px solid rgba(68, 199, 244, 0.5);
+  animation: spin 0.9s linear infinite;
+  box-shadow: 0 0 25px rgba(47, 92, 255, 0.25);
 }
 
 .label {
   font-family: var(--font-sans);
-  font-size: 0.875rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 @keyframes spin {

--- a/src/widgets/MarkdownView/MarkdownView.module.css
+++ b/src/widgets/MarkdownView/MarkdownView.module.css
@@ -2,25 +2,26 @@
   font-family: var(--font-sans);
   color: var(--text);
   display: grid;
-  gap: 1.5rem;
+  gap: 1.75rem;
   font-size: 1rem;
 }
 
 .root :is(h1, h2, h3, h4, h5, h6) {
   font-weight: 700;
-  line-height: 1.3;
+  line-height: 1.28;
+  letter-spacing: -0.01em;
 }
 
 .root h1 {
-  font-size: 2.5rem;
+  font-size: clamp(2.3rem, 5vw, 2.9rem);
 }
 
 .root h2 {
-  font-size: 2rem;
+  font-size: clamp(2rem, 4vw, 2.4rem);
 }
 
 .root h3 {
-  font-size: 1.5rem;
+  font-size: clamp(1.45rem, 3vw, 1.8rem);
 }
 
 .root p {
@@ -31,29 +32,37 @@
 .root ol {
   padding-left: 1.5rem;
   display: grid;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .root blockquote {
   margin: 0;
-  padding: 1rem 1.5rem;
-  border-left: 3px solid var(--primary);
-  background: rgba(99, 91, 255, 0.1);
+  padding: 1.1rem 1.6rem;
+  border-left: 4px solid rgba(47, 92, 255, 0.55);
+  background: linear-gradient(135deg, rgba(47, 92, 255, 0.12), rgba(68, 199, 244, 0.1));
+  border-radius: 1rem;
+  color: var(--primary-strong);
 }
 
 .root pre {
-  background: #111827;
-  color: #f9fafb;
-  padding: 1rem;
-  border-radius: 0.75rem;
+  background: linear-gradient(135deg, #143871 0%, #0f2a58 100%);
+  color: #eef4ff;
+  padding: 1.1rem 1.25rem;
+  border-radius: 1rem;
   overflow-x: auto;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+[data-theme='dark'] .root pre {
+  background: linear-gradient(135deg, #0c1c3a 0%, #040b18 100%);
+  box-shadow: inset 0 0 0 1px rgba(107, 139, 255, 0.25);
 }
 
 .root code {
-  background: rgba(99, 91, 255, 0.1);
-  border-radius: 0.25rem;
-  padding: 0.15rem 0.35rem;
+  background: rgba(47, 92, 255, 0.12);
+  border-radius: 0.4rem;
+  padding: 0.2rem 0.45rem;
 }
 
 .root pre code {
@@ -65,17 +74,20 @@
   width: 100%;
   border-collapse: collapse;
   font-size: 0.95rem;
+  overflow: hidden;
+  border-radius: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(47, 92, 255, 0.1);
 }
 
 .root th,
 .root td {
-  border: 1px solid var(--border);
-  padding: 0.75rem;
+  border: 1px solid rgba(47, 92, 255, 0.12);
+  padding: 0.85rem 1rem;
   text-align: left;
 }
 
 .root tbody tr:nth-child(even) {
-  background: rgba(99, 91, 255, 0.05);
+  background: rgba(47, 92, 255, 0.06);
 }
 
 .anchor {

--- a/src/widgets/SearchBar/SearchBar.module.css
+++ b/src/widgets/SearchBar/SearchBar.module.css
@@ -1,8 +1,19 @@
 .form {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  width: min(420px, 100%);
+  gap: 0.75rem;
+  width: min(460px, 100%);
+  padding: 0.6rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: var(--shadow);
+  backdrop-filter: var(--glass-blur);
+}
+
+[data-theme='dark'] .form {
+  background: rgba(13, 25, 52, 0.9);
+  border-color: rgba(107, 139, 255, 0.3);
 }
 
 .label {
@@ -11,38 +22,52 @@
 
 .input {
   width: 100%;
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.5rem;
-  border: 1px solid var(--border);
-  background: var(--bg);
+  padding: 0.55rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.9);
   color: var(--text);
   font-family: var(--font-sans);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+[data-theme='dark'] .input {
+  background: rgba(13, 25, 52, 0.95);
+  color: var(--text);
 }
 
 .input:focus-visible {
-  outline: 2px solid var(--primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--primary), 0 12px 24px -20px rgba(47, 92, 255, 0.75);
+  transform: translateY(-1px);
 }
 
 .button {
-  padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
   border: none;
-  background: var(--primary);
+  background: linear-gradient(135deg, var(--primary), var(--primary-strong));
   color: #fff;
   cursor: pointer;
   font-weight: 600;
   font-family: var(--font-sans);
-  transition: opacity 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 18px 32px -24px rgba(47, 92, 255, 0.9);
 }
 
 .button:hover,
 .button:focus-visible {
-  opacity: 0.9;
+  transform: translateY(-1px);
+  box-shadow: 0 24px 40px -24px rgba(47, 92, 255, 0.9);
 }
 
 @media (max-width: 640px) {
   .form {
     width: 100%;
+    padding: 0.5rem 0.6rem;
+  }
+
+  .button {
+    flex: 0 0 auto;
   }
 }

--- a/src/widgets/Toc/Toc.module.css
+++ b/src/widgets/Toc/Toc.module.css
@@ -1,17 +1,34 @@
 .root {
-  width: 280px;
+  width: 300px;
   flex-shrink: 0;
-  background: var(--bg-elev);
-  border-right: 1px solid var(--border);
-  padding: 1.5rem 1rem;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid transparent;
+  padding: 1.75rem 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  max-height: calc(100vh - 120px);
+  gap: 1.25rem;
+  max-height: calc(100vh - 128px);
   position: sticky;
-  top: 96px;
+  top: 112px;
   overflow-y: auto;
-  transition: transform 0.3s ease;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: var(--glass-blur);
+}
+
+[data-theme='dark'] .root {
+  background: rgba(13, 25, 52, 0.88);
+}
+
+.root::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background: var(--gradient-card);
+  opacity: 0.85;
+  z-index: -1;
 }
 
 .open {
@@ -29,9 +46,9 @@
 }
 
 .title {
-  font-size: 1rem;
+  font-size: 0.95rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   color: var(--muted);
 }
 
@@ -41,6 +58,8 @@
   border: none;
   color: var(--muted);
   cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.05em;
 }
 
 .nav {
@@ -52,14 +71,15 @@
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .chapterTitle {
-  font-weight: 600;
+  font-weight: 700;
   color: var(--text);
   display: block;
   margin-bottom: 0.5rem;
+  letter-spacing: 0.01em;
 }
 
 .sectionList {
@@ -67,30 +87,35 @@
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.25rem;
+  gap: 0.3rem;
 }
 
 .section {
   width: 100%;
   text-align: left;
-  background: transparent;
+  background: rgba(255, 255, 255, 0.55);
   border: none;
   color: var(--muted);
-  font-size: 0.95rem;
-  padding: 0.35rem 0.5rem;
-  border-radius: 0.5rem;
+  font-size: 0.93rem;
+  padding: 0.45rem 0.7rem;
+  border-radius: 0.75rem;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background 0.25s ease, color 0.25s ease, transform 0.2s ease;
+}
+
+[data-theme='dark'] .section {
+  background: rgba(13, 25, 52, 0.75);
 }
 
 .section:hover,
 .section:focus-visible {
-  background: rgba(99, 91, 255, 0.08);
-  color: var(--primary);
+  background: rgba(47, 92, 255, 0.18);
+  color: var(--primary-strong);
+  transform: translateX(2px);
 }
 
 .active {
-  background: rgba(99, 91, 255, 0.12);
+  background: rgba(47, 92, 255, 0.22);
   color: var(--primary);
   font-weight: 600;
 }
@@ -98,18 +123,19 @@
 @media (max-width: 1024px) {
   .root {
     position: fixed;
-    top: 0;
-    left: 0;
-    height: 100vh;
+    top: 24px;
+    left: 24px;
+    right: 24px;
+    width: auto;
+    height: calc(100vh - 48px);
     max-height: none;
-    z-index: 20;
-    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
+    z-index: 30;
+    box-shadow: 0 30px 60px -40px rgba(16, 32, 74, 0.65);
   }
 
   .close {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
-    font-weight: 600;
+    gap: 0.35rem;
   }
 }


### PR DESCRIPTION
## Summary
- refresh the global design tokens and background to use bright gradient surfaces and a glassmorphism-inspired palette
- restyle the layout chrome, home feed, article view, search, and auth pages with curved cards, gradients, and pill controls to match the requested aesthetic
- update shared widgets such as the search bar, table of contents, markdown renderer, and loading spinner to align with the new visual language

## Testing
- npm run lint *(fails: existing prettier/react-refresh issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e392e3736c832ab18c288c2143a35c